### PR TITLE
Add previews for other token types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "publisher": "JamieMaguire",
   "description": "This is a prototype for a VSCode extension that provides completions for PIE Design System tokens. This is a personal project and not an official PIE Design System product.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "engines": {
     "vscode": "^1.79.0"
   },

--- a/src/completion/createCssVariableCompletionData.ts
+++ b/src/completion/createCssVariableCompletionData.ts
@@ -31,29 +31,25 @@ export function createCssVariableCompletionData(cssString: string): CssVariableT
                     currentGroup[tokenType] = {};
                 }
 
-                const isColor = tokenType === 'color';
                 let detail : string | undefined;
 
-                // Color previews
-                if (isColor) {
-                    if (isGlobal) {
-                        // Read the value directly
-                        detail = variableValue.replace(/;/, '').trim();
-                    } else {
-                        /**
-                         * For alias tokens that rely on a global token,
-                         * e.g., `--dt-color-interactive-brand: var(--dt-color-orange);`
-                         * we need to fetch the underlying value for that global token
-                         */
-                        const doesTokenContainVariableRegex = new RegExp(/var\((.*?)\)/);
-                        // The regex uses a capturing group to extract the name of the global token
-                        const globalTokenName = doesTokenContainVariableRegex.exec(variableValue)?.[1];
+                if (isGlobal) {
+                    // Read the value directly
+                    detail = variableValue.replace(/;/, '').trim();
+                } else {
+                    /**
+                     * For alias tokens that rely on a global token,
+                     * e.g., `--dt-color-interactive-brand: var(--dt-color-orange);`
+                     * we need to fetch the underlying value for that global token
+                     */
+                    const doesTokenContainVariableRegex = new RegExp(/var\((.*?)\)/);
+                    // The regex uses a capturing group to extract the name of the global token
+                    const globalTokenName = doesTokenContainVariableRegex.exec(variableValue)?.[1];
 
-                        if (globalTokenName) {
-                            // Fetch the value of the global token
-                            // This assumes a global token was defined before being referenced by an alias token
-                            detail = global.color?.[globalTokenName]?.detail;
-                        }
+                    if (globalTokenName) {
+                        // Fetch the value of the global token
+                        // This assumes a global token was defined before being referenced by an alias token
+                        detail = global[tokenType]?.[globalTokenName]?.detail;
                     }
                 }
 
@@ -61,7 +57,9 @@ export function createCssVariableCompletionData(cssString: string): CssVariableT
                     body: `var(${variableName})`,
                     description: `Some neat description for \`${variableName}\` goes here! \n\n ${isGlobal ? globalTokenMessage : ''} \n\n [pie.design reference](https://pie.design/foundations/colour/tokens/global#${prefix})`,
                     detail,
-                    kind: isColor ? vscode.CompletionItemKind.Color : vscode.CompletionItemKind.Variable,
+                    kind: tokenType === 'color'
+                        ? vscode.CompletionItemKind.Color
+                        : vscode.CompletionItemKind.Variable,
                     label: `${prefix.replace('dt-', '')} - PIE Design Token ${isGlobal ? '(Global)' : '(Alias)'}`,
                     prefix,
 				};


### PR DESCRIPTION
> **Note** 
> If the preview is too truncated and you don't feel like using the mouse to expand the popover, you can press Ctrl+Space which opens up another popover with more information!

| Token Type | Screenshot |
| --- | --- |
| Elevation | ![2023-07-21 10_50_43](https://github.com/jamieomaguire/pie-vscode/assets/26894168/7edd5c23-30a8-4c83-b75c-8d37feca0de3) |
| Font | ![2023-07-21 10_46_51](https://github.com/jamieomaguire/pie-vscode/assets/26894168/2a5902c6-7a32-46ea-8f56-0d79fe53e08f) |
| Radius | ![2023-07-21 10_45_48](https://github.com/jamieomaguire/pie-vscode/assets/26894168/420f8c22-124c-4f34-a3b1-002df1fc8fee) |
| Spacing | ![2023-07-21 10_35_00](https://github.com/jamieomaguire/pie-vscode/assets/26894168/2c538269-46f3-40d2-9842-bab0534ff40a) |